### PR TITLE
Allowing to customize just the Subnet CIDR on OpenStack cluster creation

### DIFF
--- a/metakube/resource_metakube_cluster_schema.go
+++ b/metakube/resource_metakube_cluster_schema.go
@@ -284,12 +284,11 @@ func metakubeResourceClusterOpenstackCloudSpecFields() map[string]*schema.Schema
 			Description:  "When specified, all worker nodes will be attached to this subnet of specified network. If not specified, a network, subnet & router will be created.",
 		},
 		"subnet_cidr": {
-			Type:         schema.TypeString,
-			Computed:     true,
-			Optional:     true,
-			ForceNew:     true,
-			RequiredWith: []string{"spec.0.cloud.0.openstack.0.network", "spec.0.cloud.0.openstack.0.subnet_id"},
-			Description:  "Change this to configure a different internal IP range for Nodes. Default: 192.168.1.0/24",
+			Type:        schema.TypeString,
+			Computed:    true,
+			Optional:    true,
+			ForceNew:    true,
+			Description: "Change this to configure a different internal IP range for Nodes. Default: 192.168.1.0/24",
 		},
 	}
 }


### PR DESCRIPTION
By allowing the provider to define the Subnet CIDR MetaKube will create all resources in OpenStack based on that CIDR.

This eliminates the additional overhead of "examples/openstack/advanced" if you just want a custom subnet CIDR.

MetaKube will still remove the resources when the cluster is marked for deletion.