### PR TITLE
Remove deprecated dnsdomain field

### DIFF
--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -71,7 +71,6 @@ The following arguments are supported:
 * `syseleven_auth` - (Optional) Useful for authenticating against [SysEleven Login](https://docs.syseleven.de/metakube/en/tutorials/external-authentication).
 * `services_cidr` - (Optional) Internal IP range for ClusterIP Services.
 * `pods_cidr` - (Optional) Internal IP range for Pods.
-* `domain_name` - (Optional) Cluster domain name.
 
 ### `cloud`
 

--- a/examples/openstack/advanced/main.tf
+++ b/examples/openstack/advanced/main.tf
@@ -173,7 +173,6 @@ resource "metakube_cluster" "cluster" {
     audit_logging       = true
     pod_node_selector   = true
     pod_security_policy = true
-    domain_name         = var.cluster_domain
     services_cidr       = "10.240.16.0/20"
     pods_cidr           = "172.25.0.0/16"
   }

--- a/metakube/resource_metakube_cluster.go
+++ b/metakube/resource_metakube_cluster.go
@@ -163,9 +163,6 @@ func metakubeResourceClusterCreate(ctx context.Context, d *schema.ResourceData, 
 		},
 	}
 	if n := clusterSpec.ClusterNetwork; n != nil {
-		if n.DNSDomain != "" {
-			createClusterSpec.DNSDomain = n.DNSDomain
-		}
 		if v := clusterSpec.ClusterNetwork.Pods; v != nil {
 			if len(v.CIDRBlocks) == 1 {
 				createClusterSpec.PodsCIDR = v.CIDRBlocks[0]

--- a/metakube/resource_metakube_cluster_schema.go
+++ b/metakube/resource_metakube_cluster_schema.go
@@ -167,13 +167,6 @@ func metakubeResourceClusterSpecFields() map[string]*schema.Schema {
 			Computed:    true,
 			Description: "Internal IP range for Pods",
 		},
-		"domain_name": {
-			Type:        schema.TypeString,
-			Optional:    true,
-			ForceNew:    true,
-			Computed:    true,
-			Description: "Internal IP range for ClusterIP Pods",
-		},
 	}
 }
 

--- a/metakube/resource_metakube_cluster_structure.go
+++ b/metakube/resource_metakube_cluster_structure.go
@@ -37,9 +37,6 @@ func metakubeResourceClusterFlattenSpec(values clusterPreserveValues, in *models
 	att["pod_node_selector"] = in.UsePodNodeSelectorAdmissionPlugin
 
 	if network := in.ClusterNetwork; network != nil {
-		if network.DNSDomain != "" {
-			att["domain_name"] = network.DNSDomain
-		}
 		if v := network.Pods; len(v.CIDRBlocks) > 0 && v.CIDRBlocks[0] != "" {
 			att["pods_cidr"] = v.CIDRBlocks[0]
 		}
@@ -361,15 +358,6 @@ func metakubeResourceClusterExpandSpec(p []interface{}, dcName string) *models.C
 			obj.ClusterNetwork.Pods = &models.NetworkRanges{
 				CIDRBlocks: []string{vv},
 			}
-		}
-	}
-
-	if v, ok := in["domain_name"]; ok {
-		if vv, ok := v.(string); ok && v != "" {
-			if obj.ClusterNetwork == nil {
-				obj.ClusterNetwork = &models.ClusterNetworkingConfig{}
-			}
-			obj.ClusterNetwork.DNSDomain = vv
 		}
 	}
 

--- a/metakube/resource_metakube_cluster_structure_test.go
+++ b/metakube/resource_metakube_cluster_structure_test.go
@@ -31,7 +31,6 @@ func TestMetakubeClusterFlattenSpec(t *testing.T) {
 					Realm: "testrealm",
 				},
 				ClusterNetwork: &models.ClusterNetworkingConfig{
-					DNSDomain: "foocluster.local",
 					Services: &models.NetworkRanges{
 						CIDRBlocks: []string{"1.1.1.0/20"},
 					},
@@ -54,7 +53,6 @@ func TestMetakubeClusterFlattenSpec(t *testing.T) {
 					"pod_node_selector":   false,
 					"services_cidr":       "1.1.1.0/20",
 					"pods_cidr":           "2.2.0.0/16",
-					"domain_name":         "foocluster.local",
 					"enable_ssh_agent":    true,
 					"cloud": []interface{}{
 						map[string]interface{}{
@@ -420,7 +418,6 @@ func TestExpandClusterSpec(t *testing.T) {
 					"pod_node_selector":   true,
 					"services_cidr":       "1.1.1.0/20",
 					"pods_cidr":           "2.2.0.0/16",
-					"domain_name":         "foocluster.local",
 					"cloud": []interface{}{
 						map[string]interface{}{
 							"openstack": []interface{}{
@@ -452,7 +449,6 @@ func TestExpandClusterSpec(t *testing.T) {
 					Pods: &models.NetworkRanges{
 						CIDRBlocks: []string{"2.2.0.0/16"},
 					},
-					DNSDomain: "foocluster.local",
 				},
 				Cloud: &models.CloudSpec{
 					DatacenterName: "eu-west-1",

--- a/metakube/resource_metakube_cluster_test.go
+++ b/metakube/resource_metakube_cluster_test.go
@@ -96,7 +96,6 @@ func TestAccMetakubeCluster_Openstack_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "spec.0.version", data.Version),
 					resource.TestCheckResourceAttr(resourceName, "spec.0.update_window.0.start", "Tue 02:00"),
 					resource.TestCheckResourceAttr(resourceName, "spec.0.update_window.0.length", "2h"),
-					resource.TestCheckResourceAttr(resourceName, "spec.0.domain_name", "foodomain.local"),
 					resource.TestCheckResourceAttr(resourceName, "spec.0.services_cidr", "10.240.16.0/18"),
 					resource.TestCheckResourceAttr(resourceName, "spec.0.pods_cidr", "172.25.0.0/18"),
 					resource.TestCheckResourceAttr(resourceName, "spec.0.cloud.#", "1"),
@@ -168,7 +167,6 @@ func TestAccMetakubeCluster_Openstack_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "spec.0.version", data.Version),
 					resource.TestCheckResourceAttr(resourceName, "spec.0.update_window.0.start", "Wed 12:00"),
 					resource.TestCheckResourceAttr(resourceName, "spec.0.update_window.0.length", "3h"),
-					resource.TestCheckResourceAttr(resourceName, "spec.0.domain_name", "foodomain.local"),
 					resource.TestCheckResourceAttr(resourceName, "spec.0.services_cidr", "10.240.16.0/18"),
 					resource.TestCheckResourceAttr(resourceName, "spec.0.pods_cidr", "172.25.0.0/18"),
 					resource.TestCheckResourceAttr(resourceName, "spec.0.pod_node_selector", "true"),
@@ -408,7 +406,6 @@ resource "metakube_cluster" "acctest_cluster" {
 				subnet_cidr = "192.168.2.0/24"
 			}
 		}
-		domain_name = "foodomain.local"
 		services_cidr = "10.240.16.0/18"
 		pods_cidr = "172.25.0.0/18"
 	}
@@ -527,7 +524,6 @@ resource "metakube_cluster" "acctest_cluster" {
 
 		pod_node_selector = true
 		pod_security_policy = true
-		domain_name = "foodomain.local"
 		services_cidr = "10.240.16.0/18"
 		pods_cidr = "172.25.0.0/18"
 	}


### PR DESCRIPTION
Remove field that allows to override the default dnsdomain of
cluster.local as this feature has been deprecated.