### PR TITLE
Minor improvements to provider documentation

### DIFF
--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -6,7 +6,7 @@ Cluster resource in the provider defines the corresponding cluster in MetaKube.
 
 ```hcl
 resource "metakube_cluster" "example" {
-  project_id = metakube_project.example.id
+  project_id = "example-project-id"
   name = "example"
   dc_name = "europe-west3-c"
 

--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -48,6 +48,7 @@ The following arguments are supported:
 
 ## Attributes
 
+* `id` - Cluster identifier.
 * `kube_config` - Admin kube config raw content which can be dumped to a file using [local_file](https://registry.terraform.io/providers/hashicorp/local/latest/docs/resources/file). You might want to use `oidc_kube_config` or `kube_login_kube_config` together with `syseleven_auth` configured for better security.
 * `oidc_kube_config` - Plain Open ID Connect kube config raw content which can be dumped to a file using [local_file](https://registry.terraform.io/providers/hashicorp/local/latest/docs/resources/file). To use `syseleven_auth` should be configured too.
 * `kube_login_kube_config` - The `kubelogin` config content which can be dumped to a file using [local_file](https://registry.terraform.io/providers/hashicorp/local/latest/docs/resources/file). To use `syseleven_auth` should be configured too.

--- a/docs/resources/node_deployment.md
+++ b/docs/resources/node_deployment.md
@@ -6,7 +6,7 @@ Node deployment resource in the provider defines the corresponding deployment of
 
 ```hcl
 resource "metakube_node_deployment" "example_node" {
-  cluster_id = metakube_project.example_project.id + ":europe-west3-c:" + metakube_cluster.example_cluster.id
+  cluster_id = metakube_cluster.example_cluster.id
   spec {
     replicas = 1
     template {

--- a/docs/resources/node_deployment.md
+++ b/docs/resources/node_deployment.md
@@ -5,6 +5,10 @@ Node deployment resource in the provider defines the corresponding deployment of
 ## Example usage
 
 ```hcl
+resource "metakube_cluster" "example_cluster" {
+  # [...]
+}
+
 resource "metakube_node_deployment" "example_node" {
   cluster_id = metakube_cluster.example_cluster.id
   spec {

--- a/docs/resources/sshkey.md
+++ b/docs/resources/sshkey.md
@@ -6,7 +6,7 @@ SSH Key resource in the provider defines the corresponding sshkey with public ke
 
 ```hcl
 resource "metakube_sshkey" "example" {
-  project_id = metakube_project.example.id
+  project_id = "example-project-id"
   name = "example"
   public_key = "ssh-rsa ... foo@bar.net"
 }


### PR DESCRIPTION
- Documents the existence of the `id` attribute exported by `metakube_cluster` resources.
- Removes references to non-existing `metakube_project` resources.
