### PR TITLE
fix cluster example usage

### DIFF
--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -23,7 +23,7 @@ resource "metakube_cluster" "example" {
 
 # create admin.conf file
 resource "local_file" "kubeconfig" {
-  content     = metakube_cluster.cluster.kube_config
+  content     = metakube_cluster.example.kube_config
   filename = "${path.module}/admin.conf"
 }
 ```


### PR DESCRIPTION
The cluster resource in the example is called `example` so it should be referenced by using the same name.