### PR TITLE
K8s-8344 Save cluster resource even if ready check timed out

### DIFF
--- a/examples/openstack/advanced/main.tf
+++ b/examples/openstack/advanced/main.tf
@@ -136,7 +136,7 @@ resource "metakube_sshkey" "local" {
 
 data "metakube_k8s_version" "cluster" {
   major = "1"
-  minor = "21"
+  minor = "26"
 }
 
 resource "metakube_cluster" "cluster" {

--- a/examples/openstack/basic/main.tf
+++ b/examples/openstack/basic/main.tf
@@ -49,7 +49,7 @@ resource "metakube_sshkey" "local" {
 
 data "metakube_k8s_version" "cluster" {
   major = "1"
-  minor = "21"
+  minor = "26"
 }
 
 resource "metakube_cluster" "cluster" {


### PR DESCRIPTION
Make sure that we save the cluster resource in the terraform state even if the cluster ready check times out.
In this case the resource will be tainted and can be replaced (or repaired) on a retry instead of getting duplicate cluster error messages or creating unnecessary duplicates