### PR TITLE
K8s-9090 Remove dynamic kubelet config option

### DIFF
--- a/docs/resources/node_deployment.md
+++ b/docs/resources/node_deployment.md
@@ -65,7 +65,6 @@ The following arguments are supported:
 
 * `replicas` - (Optional) Number of replicas, default = 1.
 * `template` - (Required) Template specification.
-* `dynamic_config` - (Optional) Enable metakube dynamic kubelet config.
 * `min_replicas` - (Optional) Minimum number of replicas to downscale node deployment to. Be aware that:
   * downscaling is not supported for kubernetes versions below `1.18.0`.
   * downscaling to `0` is not supported.

--- a/examples/openstack/advanced/main.tf
+++ b/examples/openstack/advanced/main.tf
@@ -195,8 +195,6 @@ resource "metakube_node_deployment" "acctest_nd" {
     min_replicas = var.node_min_replicas
     max_replicas = var.node_max_replicas
 
-    dynamic_config = true
-
     template {
       labels = {
         key = "value"

--- a/metakube/resource_node_deployment_schema.go
+++ b/metakube/resource_node_deployment_schema.go
@@ -22,12 +22,6 @@ func metakubeResourceSystemLabelOrTag(key string) bool {
 
 func metakubeResourceNodeDeploymentSpecFields() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
-		"dynamic_config": {
-			Type:        schema.TypeBool,
-			Optional:    true,
-			Default:     false,
-			Description: "Enable metakube kubelete dynamic config",
-		},
 		"replicas": {
 			Type:          schema.TypeInt,
 			Optional:      true,

--- a/metakube/resource_node_deployment_structure.go
+++ b/metakube/resource_node_deployment_structure.go
@@ -28,8 +28,6 @@ func metakubeNodeDeploymentFlattenSpec(in *models.NodeDeploymentSpec) []interfac
 		att["template"] = metakubeNodeDeploymentFlattenNodeSpec(in.Template)
 	}
 
-	att["dynamic_config"] = in.DynamicConfig
-
 	return []interface{}{att}
 }
 
@@ -323,12 +321,6 @@ func metakubeNodeDeploymentExpandSpec(p []interface{}, isCreate bool) *models.No
 	if v, ok := in["template"]; ok {
 		if vv, ok := v.([]interface{}); ok {
 			obj.Template = metakubeNodeDeploymentExpandNodeSpec(vv)
-		}
-	}
-
-	if v, ok := in["dynamic_config"]; ok {
-		if vv, ok := v.(bool); ok {
-			obj.DynamicConfig = vv
 		}
 	}
 

--- a/metakube/resource_node_deployment_structure_test.go
+++ b/metakube/resource_node_deployment_structure_test.go
@@ -14,22 +14,20 @@ func TestMetakubeNodeDeploymentFlatten(t *testing.T) {
 	}{
 		{
 			&models.NodeDeploymentSpec{
-				Replicas:      int32ToPtr(1),
-				Template:      &models.NodeSpec{},
-				DynamicConfig: true,
+				Replicas: int32ToPtr(1),
+				Template: &models.NodeSpec{},
 			},
 			[]interface{}{
 				map[string]interface{}{
-					"replicas":       int32(1),
-					"template":       []interface{}{map[string]interface{}{}},
-					"dynamic_config": true,
+					"replicas": int32(1),
+					"template": []interface{}{map[string]interface{}{}},
 				},
 			},
 		},
 		{
 			&models.NodeDeploymentSpec{},
 			[]interface{}{
-				map[string]interface{}{"dynamic_config": false},
+				map[string]interface{}{},
 			},
 		},
 		{
@@ -379,15 +377,13 @@ func TestExpandNodeDeploymentSpec(t *testing.T) {
 		{
 			[]interface{}{
 				map[string]interface{}{
-					"replicas":       1,
-					"template":       []interface{}{map[string]interface{}{}},
-					"dynamic_config": true,
+					"replicas": 1,
+					"template": []interface{}{map[string]interface{}{}},
 				},
 			},
 			&models.NodeDeploymentSpec{
-				Replicas:      int32ToPtr(1),
-				Template:      &models.NodeSpec{},
-				DynamicConfig: true,
+				Replicas: int32ToPtr(1),
+				Template: &models.NodeSpec{},
 			},
 		},
 		{

--- a/metakube/resource_node_deployment_test.go
+++ b/metakube/resource_node_deployment_test.go
@@ -50,7 +50,6 @@ func TestAccMetakubeNodeDeployment_Openstack_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "spec.0.template.0.cloud.0.openstack.0.image", image),
 					resource.TestCheckResourceAttr(resourceName, "spec.0.template.0.operating_system.0.ubuntu.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "spec.0.template.0.versions.0.kubelet", k8sVersionOld),
-					resource.TestCheckResourceAttr(resourceName, "spec.0.dynamic_config", "false"),
 				),
 			},
 			{
@@ -75,7 +74,6 @@ func TestAccMetakubeNodeDeployment_Openstack_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "spec.0.template.0.cloud.0.openstack.0.disk_size", "8"),
 					resource.TestCheckResourceAttr(resourceName, "spec.0.template.0.operating_system.0.ubuntu.0.dist_upgrade_on_boot", "true"),
 					resource.TestCheckResourceAttr(resourceName, "spec.0.template.0.versions.0.kubelet", k8sVersionNew),
-					resource.TestCheckResourceAttr(resourceName, "spec.0.dynamic_config", "true"),
 				),
 			},
 			{
@@ -192,7 +190,6 @@ func testAccCheckMetaKubeNodeDeploymentBasic2(projectID, testName, nodeDC, usern
 		cluster_id = metakube_cluster.acctest_cluster.id
 		name = "%s"
 		spec {
-			dynamic_config = true
 			replicas = 1
 			template {
 				labels = {


### PR DESCRIPTION
Since 1.24 dynamic kubelet config isn't supported by kubernetes anymore. 
Remove the dynamic kubelet config option after the deprecation of 1.23 in metakube.