### PR TITLE
#174598 improve wording of disk_size explanation

### DIFF
--- a/docs/resources/node_deployment.md
+++ b/docs/resources/node_deployment.md
@@ -115,7 +115,7 @@ One of the following must be selected.
 ### `openstack`
 * `flavor` - (Required) Instance type.
 * `image` - (Required) Image to use.
-* `disk_size` - (Optional) Set disk size when network storage flavors is used.
+* `disk_size` - (Optional) If set, the rootDisk will be a cinder volume of that size in GiB. If unset, the rootDisk will be ephemeral nova root storage and its size will be derived from the flavor.
 * `tags` - (Optional) Additional instance tags.
 * `use_floating_ip` - (Optional) Indicate use of floating ip in case of floating_ip_pool presense. Defaults to true.
 * `instance_ready_check_period` - (Optional) Specify custom value for how often to check if instance is ready before timing out.

--- a/metakube/resource_node_deployment_schema.go
+++ b/metakube/resource_node_deployment_schema.go
@@ -292,7 +292,7 @@ func matakubeResourceNodeDeploymentCloudOpenstackSchema() map[string]*schema.Sch
 			Type:         schema.TypeInt,
 			Optional:     true,
 			ValidateFunc: validation.IntAtLeast(1),
-			Description:  "If set, the rootDisk will be a volume. If not, the rootDisk will be on ephemeral storage and its size will be derived from the flavor",
+			Description:  "If set, the rootDisk will be a cinder volume of that size in GiB. If unset, the rootDisk will be ephemeral nova root storage and its size will be derived from the flavor",
 		},
 		"tags": {
 			Type:        schema.TypeMap,


### PR DESCRIPTION
Improve wording of disk_size explanation to clarify that setting this parameter will replace nova ephemeral root storage of fixed size with cinder volume storage of variable size.