### PR TITLE
K8s-11784 fix node deployment min/max replicas handling

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/hashicorp/go-version v1.6.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.30.0
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/syseleven/go-metakube v0.0.0-20241209175334-b03f742212c2
+	github.com/syseleven/go-metakube v0.0.0-20250228171952-0b36d01eaad2
 	go.uber.org/zap v1.19.0
 	golang.org/x/mod v0.14.0
 	k8s.io/utils v0.0.0-20241104163129-6fe5fd82f078

--- a/go.sum
+++ b/go.sum
@@ -179,8 +179,8 @@ github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-github.com/syseleven/go-metakube v0.0.0-20241209175334-b03f742212c2 h1:KfPt3bgBgMa9/9VzuwVoIjmLRkg9mjGBaeRL88VPPb4=
-github.com/syseleven/go-metakube v0.0.0-20241209175334-b03f742212c2/go.mod h1:KJB8m9a51Dcci9ee2pLwKetFm9MUrOAjDPAm5ZnOnHI=
+github.com/syseleven/go-metakube v0.0.0-20250228171952-0b36d01eaad2 h1:1OVBH4m+vP1gqGkqhvIR2L+cMRg7WjUxQPciPVSPufI=
+github.com/syseleven/go-metakube v0.0.0-20250228171952-0b36d01eaad2/go.mod h1:KJB8m9a51Dcci9ee2pLwKetFm9MUrOAjDPAm5ZnOnHI=
 github.com/syseleven/terraform-plugin-sdk/v2 v2.31.0-sys11-2 h1:vywVVW9AnKcEiqgbZe16wwuaQaZ8VtMe+xmNBdvdMnU=
 github.com/syseleven/terraform-plugin-sdk/v2 v2.31.0-sys11-2/go.mod h1:i2C41tszDjiWfziPQDL5R/f3Zp0gahXe5No/MIO9rCE=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=

--- a/metakube/resource_node_deployment_structure.go
+++ b/metakube/resource_node_deployment_structure.go
@@ -317,7 +317,7 @@ func metakubeNodeDeploymentExpandSpec(p []interface{}, isCreate bool) *models.No
 		}
 	}
 
-	if v, ok := in["replicas"]; ok && *obj.MinReplicas == 0 {
+	if v, ok := in["replicas"]; ok && (obj.MinReplicas == nil || *obj.MinReplicas == 0) {
 		if vv, ok := v.(int); ok {
 			obj.Replicas = int32ToPtr(int32(vv))
 		}


### PR DESCRIPTION
These fields were turned into pointers in the API so they can be set to 0, which wasn't previously possible.