### PR TITLE
K8s-13460 Add ipfamily field

### DIFF
--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -73,6 +73,7 @@ The following arguments are supported:
 * `services_cidr` - (Optional) Internal IP range for ClusterIP Services.
 * `pods_cidr` - (Optional) Internal IP range for Pods.
 * `cni_plugin` - (Optional) CNI plugin used by the Cluster.
+* `ip_family` - (Optional) IP family to use for the Cluster.
 
 ### `cloud`
 

--- a/metakube/resource_cluster_schema.go
+++ b/metakube/resource_cluster_schema.go
@@ -161,6 +161,12 @@ func metakubeResourceClusterSpecFields() map[string]*schema.Schema {
 				},
 			},
 		},
+		"ip_family": {
+			Type:         schema.TypeString,
+			Optional:     true,
+			ValidateFunc: validation.StringInSlice([]string{"IPv4", "IPv4+IPv6"}, false),
+			Description:  "Represents IP address family to use for the Cluster",
+		},
 	}
 }
 

--- a/metakube/resource_cluster_structure.go
+++ b/metakube/resource_cluster_structure.go
@@ -41,6 +41,9 @@ func metakubeResourceClusterFlattenSpec(values clusterPreserveValues, in *models
 		if v := network.Services; len(v.CIDRBlocks) > 0 && v.CIDRBlocks[0] != "" {
 			att["services_cidr"] = v.CIDRBlocks[0]
 		}
+		if network.IPFamily != "" {
+			att["ip_family"] = string(network.IPFamily)
+		}
 	}
 
 	if in.CniPlugin != nil && in.CniPlugin.Type != "" {
@@ -363,6 +366,15 @@ func metakubeResourceClusterExpandSpec(p []interface{}, dcName string, include f
 	if v, ok := in["cni_plugin"]; ok {
 		if vv, ok := v.([]interface{}); ok {
 			obj.CniPlugin = expandCniPlugin(vv)
+		}
+	}
+
+	if v, ok := in["ip_family"]; ok && include("ip_family") {
+		if vv, ok := v.(string); ok && vv != "" {
+			if obj.ClusterNetwork == nil {
+				obj.ClusterNetwork = &models.ClusterNetworkingConfig{}
+			}
+			obj.ClusterNetwork.IPFamily = models.IPFamily(vv)
 		}
 	}
 

--- a/metakube/resource_cluster_structure_test.go
+++ b/metakube/resource_cluster_structure_test.go
@@ -37,6 +37,7 @@ func TestMetakubeClusterFlattenSpec(t *testing.T) {
 					Pods: &models.NetworkRanges{
 						CIDRBlocks: []string{"2.2.0.0/16"},
 					},
+					IPFamily: models.IPFamily("IPv4"),
 				},
 				CniPlugin: &models.CNIPluginSettings{
 					Type: models.CNIPluginType("canal"),
@@ -61,6 +62,7 @@ func TestMetakubeClusterFlattenSpec(t *testing.T) {
 							"type": "canal",
 						},
 					},
+					"ip_family":        "IPv4",
 					"enable_ssh_agent": true,
 					"cloud": []interface{}{
 						map[string]interface{}{
@@ -443,6 +445,7 @@ func TestExpandClusterSpec(t *testing.T) {
 							"type": "canal",
 						},
 					},
+					"ip_family": "IPv4",
 					"cloud": []interface{}{
 						map[string]interface{}{
 							"openstack": []interface{}{
@@ -473,6 +476,7 @@ func TestExpandClusterSpec(t *testing.T) {
 					Pods: &models.NetworkRanges{
 						CIDRBlocks: []string{"2.2.0.0/16"},
 					},
+					IPFamily: models.IPFamily("IPv4"),
 				},
 				Cloud: &models.CloudSpec{
 					DatacenterName: "eu-west-1",


### PR DESCRIPTION
Adding ip family field to the TF provider
Related [docs](https://documentation.syseleven.de/en/products/metakube-core/concepts/networking/ipv6/#prerequisites)
